### PR TITLE
stopCallback would fail in XML/XHTML documents

### DIFF
--- a/Combokeys/prototype/stopCallback.js
+++ b/Combokeys/prototype/stopCallback.js
@@ -14,6 +14,8 @@ module.exports = function (e, element) {
     return false
   }
 
+  var tagName = element.tagName.toLowerCase()
+
   // stop for input, select, and textarea
-  return element.tagName === 'INPUT' || element.tagName === 'SELECT' || element.tagName === 'TEXTAREA' || element.isContentEditable
+  return tagName === 'input' || tagName === 'select' || tagName === 'textarea' || element.isContentEditable
 }

--- a/package.js
+++ b/package.js
@@ -8,7 +8,7 @@ Package.implements = ['CommonJS/Modules/1.0']
 Package.scripts = {
   lint: 'standard',
   unit: './node_modules/zuul/bin/zuul --phantom -- test/test.combokeys.js test/plugins/test.*.js',
-  build: 'mkdir dist && browserify index.js -o dist/combokeys.js --standalone Combokeys',
+  build: 'mkdir -p dist && browserify index.js -o dist/combokeys.js --standalone Combokeys',
   test: 'npm run lint && npm run unit && npm run build'
 
 }

--- a/package.js
+++ b/package.js
@@ -53,3 +53,8 @@ Package.devDependencies = {
 Package.dependencies = {
   'add-event-handler': '^1.0.0'
 }
+Package.standard = {
+  ignore: [
+    'dist/**'
+  ]
+}

--- a/test/lib/key-event.js
+++ b/test/lib/key-event.js
@@ -56,7 +56,7 @@ KeyEvent.simulate = function (charCode, keyCode, modifiers, element, repeat) {
   }
 
   if (element === undefined) {
-    element = document
+    element = document.documentElement
   }
 
   if (repeat === undefined) {

--- a/test/test.combokeys.js
+++ b/test/test.combokeys.js
@@ -115,7 +115,7 @@ describe('combokeys.bind', function () {
       expect(spy.callCount).to.equal(1, 'keyup event for `z` should fire')
 
       // for key held down we should only get one key up
-      KeyEvent.simulate('Z'.charCodeAt(0), 90, [], document, 10)
+      KeyEvent.simulate('Z'.charCodeAt(0), 90, [], document.documentElement, 10)
       expect(spy.callCount).to.equal(2, 'keyup event for `z` should fire once for held down key')
     })
 
@@ -383,7 +383,7 @@ describe('combokeys.bind', function () {
       KeyEvent.simulate('a'.charCodeAt(0), 65)
 
       // hold the last key down for a while
-      KeyEvent.simulate('t'.charCodeAt(0), 84, [], document, 10)
+      KeyEvent.simulate('t'.charCodeAt(0), 84, [], document.documentElement, 10)
 
       expect(spy.callCount).to.equal(1, 'callback for `b a t` sequence should fire on keyup')
     })


### PR DESCRIPTION
I have no idea why anyone would be using these, but just in case this fixes stopCallback from producing invalid results.

I also made some updates to the tests because of errors and fails.