### PR TITLE
Inline dom event (closes #46)

### DIFF
--- a/Combokeys/prototype/addEvents.js
+++ b/Combokeys/prototype/addEvents.js
@@ -2,7 +2,7 @@
 'use strict'
 module.exports = function () {
   var self = this
-  var on = require('dom-event')
+  var on = require('./dom-event')
   var element = self.element
 
   self.eventHandler = require('./handleKeyEvent').bind(self)

--- a/Combokeys/prototype/detach.js
+++ b/Combokeys/prototype/detach.js
@@ -1,4 +1,4 @@
-var off = require('dom-event').off
+var off = require('./dom-event').off
 module.exports = function () {
   var self = this
   var element = self.element

--- a/Combokeys/prototype/dom-event.js
+++ b/Combokeys/prototype/dom-event.js
@@ -1,0 +1,15 @@
+module.exports = on
+module.exports.on = on
+module.exports.off = off
+
+function on (element, event, callback, capture) {
+  !element.addEventListener && (event = 'on' + event)
+  ;(element.addEventListener || element.attachEvent).call(element, event, callback, capture)
+  return callback
+}
+
+function off (element, event, callback, capture) {
+  !element.removeEventListener && (event = 'on' + event)
+  ;(element.removeEventListener || element.detachEvent).call(element, event, callback, capture)
+  return callback
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,4 @@
 {
-  "dependencies": {
-    "dom-event": "^0.0.5"
-  },
   "devDependencies": {
     "standard": "*",
     "browserify": "^9.0.3",


### PR DESCRIPTION
This closes issue #46 

Here's what I did:

  * Copy-paste dom-event source code
  * Manually reformat it to standard javascript format
  * Removed 'dom-event' dependency & diverted two requires
  * Made sure 'npm test' passed
  * Published [my own fork](https://www.npmjs.com/package/combokeys-ftl) so I can use the fix before it's merged & published upstream :)